### PR TITLE
Add data source checking

### DIFF
--- a/yodapy/utils/creds.py
+++ b/yodapy/utils/creds.py
@@ -16,16 +16,20 @@ from yodapy.utils.files import (CREDENTIALS_FILE,
 
 def set_credentials_file(data_source=None, username=None, token=None):
     if data_source:
-        if username and token:
-            if check_file_permissions():
-                with open(CREDENTIALS_FILE, 'w') as f:
-                    FILE_CONTENT[CREDENTIALS_FILE][data_source] = {'username': username,  # noqa
-                                                                   'api_key': token}  # noqa
-                    f.write(json.dumps(FILE_CONTENT[CREDENTIALS_FILE]))
+        data_source = data_source.lower()
+        if data_source in ['ooi']:
+            if username and token:
+                if check_file_permissions():
+                    with open(CREDENTIALS_FILE, 'w') as f:
+                        FILE_CONTENT[CREDENTIALS_FILE][data_source] = {'username': username,  # noqa
+                                                                       'api_key': token}  # noqa
+                        f.write(json.dumps(FILE_CONTENT[CREDENTIALS_FILE]))
+                else:
+                    warnings.warn('You don\'t have a read-write permission '
+                                  'to your home (\'~\') directory!')
             else:
-                warnings.warn('You don\'t have a read-write permission '
-                              'to your home (\'~\') directory!')
+                warnings.warn('Please enter your username and token!')
         else:
-            warnings.warn('Please enter your username and token!')
+            warnings.warn(f'Datasource: {data_source} is not valid. Available: ooi')
     else:
         warnings.warn('Please specify a data_source. Available: ooi')


### PR DESCRIPTION
## Overview

This PR adds `data_source` checking when setting credential file

Resolves #40 

### Demo

```
In [1]: import yodapy

In [2]: yodapy.utils.set_credentials_file(data_source='foo', username='test', token='whatever')
/home/lsetiawan/GitRepos/GitHub/cormorack/yodapy/yodapy/utils/creds.py:33: UserWarning: Datasource: foo is not valid. Available: ooi
  warnings.warn(f'Datasource: {data_source} is not valid. Available: ooi')

In [3]: import os

In [4]: os.path.exists(os.path.join(os.path.expanduser('~'), '.yodapy', '.credentials'))
Out[4]: False
```

### Test Instruction

1. Install `yodapy` from `lsetiawan/add_checking` branch.
```
pip install git+https://github.com/lsetiawan/yodapy.git@add_checking
```
2. Open up Ipython and run demo above.
