### PR TITLE
Add preprocessing and use own function to interpret time

### DIFF
--- a/yodapy/datasources/ooi/__init__.py
+++ b/yodapy/datasources/ooi/__init__.py
@@ -1,24 +1,21 @@
 # -*- coding: utf-8 -*-
 
-import os
-import glob
-import re
-import sys
 import logging
-import datetime
-
-import requests
+import os
+import re
 
 from dask.distributed import (Client, as_completed, progress)
+
 import pandas as pd
+
+import requests
 
 import xarray as xr
 
 from yodapy.datasources.datasource import DataSource
-from yodapy.datasources.ooi.m2m_client import M2MClient
 from yodapy.datasources.ooi.helpers import preprocess_ds
+from yodapy.datasources.ooi.m2m_client import M2MClient
 from yodapy.utils.parser import get_nc_urls
-from yodapy.utils.conn import requests_retry_session
 
 SOURCE_NAME = 'OOI'
 
@@ -282,7 +279,7 @@ class OOI(DataSource):
         self.last_request_urls = request_urls
 
         client = Client()
-        print(client)
+        self._logger.debug(f'request_data dask client: {client}')
         futures = client.map(lambda url: self._client.send_request(url),
                              request_urls)
         progress(futures)
@@ -326,7 +323,7 @@ class OOI(DataSource):
         # TODO: Add way to specify instruments to convert to xarray
         if self._data_type == 'netcdf':
             client = Client()
-            print(client)
+            self._logger.debug(f'to_xarray dask client: {client}')
             futures = client.map(lambda durl: self._check_data_status(durl),
                                  self._data_urls)
             progress(futures)

--- a/yodapy/datasources/ooi/__init__.py
+++ b/yodapy/datasources/ooi/__init__.py
@@ -16,6 +16,7 @@ import xarray as xr
 
 from yodapy.datasources.datasource import DataSource
 from yodapy.datasources.ooi.m2m_client import M2MClient
+from yodapy.datasources.ooi.helpers import preprocess_ds
 from yodapy.utils.parser import get_nc_urls
 from yodapy.utils.conn import requests_retry_session
 
@@ -48,6 +49,7 @@ class OOI(DataSource):
         self._session = requests.session()
         self.username = self._client.api_username
         self.token = self._client.api_token
+        self.last_request_urls = None
 
         self._filtered_instruments = self._instruments
         self._data_urls = None
@@ -277,8 +279,10 @@ class OOI(DataSource):
                                                                               limit=limit,
                                                                               **kwargs)[0],
                                 do_filter))
+        self.last_request_urls = request_urls
 
         client = Client()
+        print(client)
         futures = client.map(lambda url: self._client.send_request(url),
                              request_urls)
         progress(futures)
@@ -322,6 +326,7 @@ class OOI(DataSource):
         # TODO: Add way to specify instruments to convert to xarray
         if self._data_type == 'netcdf':
             client = Client()
+            print(client)
             futures = client.map(lambda durl: self._check_data_status(durl),
                                  self._data_urls)
             progress(futures)
@@ -330,7 +335,12 @@ class OOI(DataSource):
                 self._logger.debug(f'Retrieving data: {future}')
                 if result:
                     datasets = get_nc_urls(result)
-                    dataset_list.append(xr.open_mfdataset(datasets, **kwargs))
+                    dataset_list.append(xr.open_mfdataset(
+                        datasets,
+                        preprocess=preprocess_ds,
+                        decode_times=False,
+                        **kwargs)
+                    )
         else:
             self._logger.warning(f'{self._data_type} cannot be converted to xarray dataset')  # noqa
 

--- a/yodapy/datasources/ooi/helpers.py
+++ b/yodapy/datasources/ooi/helpers.py
@@ -5,13 +5,15 @@ from __future__ import (division,
                         print_function,
                         unicode_literals)
 
+import logging
 import os
 
-from dask.diagnostics import ProgressBar
 import numpy as np
 
 from yodapy.utils.conn import requests_retry_session
 from yodapy.utils.parser import seconds_to_date
+
+logger = logging.getLogger(__name__)
 
 
 def check_data_status(session, data, **kwargs):
@@ -34,8 +36,8 @@ def check_data_status(session, data, **kwargs):
 
 def preprocess_ds(ds):
     cleaned_ds = ds.swap_dims({'obs': 'time'})
-    print('DIMS SWAPPED')
+    logger.debug('DIMS SWAPPED')
     cleaned_ds['time'] = np.array(list(map(lambda x: seconds_to_date(x),
-                                        cleaned_ds.time.values)))
-    print('COMPLETE')
+                                           cleaned_ds.time.values)))
+    logger.debug('COMPLETE')
     return cleaned_ds

--- a/yodapy/datasources/ooi/helpers.py
+++ b/yodapy/datasources/ooi/helpers.py
@@ -7,7 +7,11 @@ from __future__ import (division,
 
 import os
 
+from dask.diagnostics import ProgressBar
+import numpy as np
+
 from yodapy.utils.conn import requests_retry_session
+from yodapy.utils.parser import seconds_to_date
 
 
 def check_data_status(session, data, **kwargs):
@@ -26,3 +30,12 @@ def check_data_status(session, data, **kwargs):
     print('\nRequest completed.')  # noqa
 
     return urls['thredds_url']
+
+
+def preprocess_ds(ds):
+    cleaned_ds = ds.swap_dims({'obs': 'time'})
+    print('DIMS SWAPPED')
+    cleaned_ds['time'] = np.array(list(map(lambda x: seconds_to_date(x),
+                                        cleaned_ds.time.values)))
+    print('COMPLETE')
+    return cleaned_ds

--- a/yodapy/utils/parser.py
+++ b/yodapy/utils/parser.py
@@ -22,13 +22,15 @@ def get_nc_urls(thredds_url):
 
     response = requests.get(caturl)
     ROOT = etree.XML(response.content)
-    dataset_el = list(filter(lambda x: re.match(r'(.*?.nc$)', x.attrib['urlPath']) is not None,
+    dataset_el = list(filter(lambda x: re.match(r'(.*?.nc$)',
+                             x.attrib['urlPath']) is not None,
                              ROOT.xpath('//*[contains(@urlPath, ".nc")]')))
 
     service_el = ROOT.xpath('//*[contains(@name, "odap")]')[0]
 
-    dataset_urls = [urljoin(domain, urljoin(service_el.attrib['base'], el.attrib['urlPath'])) for el in
-                    dataset_el]  # noqa
+    dataset_urls = [urljoin(domain,
+                            urljoin(service_el.attrib['base'],
+                                    el.attrib['urlPath'])) for el in dataset_el]  # noqa
 
     return dataset_urls
 


### PR DESCRIPTION
## Overview

This PR adds a preprocessing step to the opendap dataset. This adds overhead to the `to_xarray` function. Optimization is needed to make it faster, currently it takes about 2 min for 1 day of data from instruments in #48.

### Demo
```python
In [36]: %time ds_list = ooi.to_xarray()
    ...:
[########################################] | 100% Completed |  0.7sDIMS SWAPPED
COMPLETE
DIMS SWAPPED
COMPLETE
DIMS SWAPPED
COMPLETE
CPU times: user 1min 47s, sys: 1min 34s, total: 3min 21s
Wall time: 2min 2s
```

### Notes

- Not fully optimized, don't request big data yet.

## Testing Instructions

- Try with some cabled array instruments.
- Use `%time` on `to_xarray()` function and try out different range of data request.
