### PR TITLE
Filter reference designator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,6 +105,7 @@ ENV/
 
 # VS Code
 .vscode
+.vs/
 
 # credentials
 .creds.json
@@ -121,3 +122,5 @@ dask-worker-space/
 # cpsarason_examples
 examples/example*
 
+#inis
+*.ini

--- a/yodapy/datasources/ooi/__init__.py
+++ b/yodapy/datasources/ooi/__init__.py
@@ -381,7 +381,7 @@ class OOI(DataSource):
         # TODO: What to do when it's JSON request, calling on to_xarray.
         # TODO: Standardize the structure of the netCDF to ensure CF compliance.
         # TODO: Add way to specify instruments to convert to xarray
-        ref_degs = self.view_instruments()["reference_designator"].values
+        ref_degs = self._filtered_instruments()["reference_designator"].values
         if self._data_type == 'netcdf':
             turls = self._perform_check()
             if len(turls) > 0:

--- a/yodapy/datasources/ooi/__init__.py
+++ b/yodapy/datasources/ooi/__init__.py
@@ -381,11 +381,12 @@ class OOI(DataSource):
         # TODO: What to do when it's JSON request, calling on to_xarray.
         # TODO: Standardize the structure of the netCDF to ensure CF compliance.
         # TODO: Add way to specify instruments to convert to xarray
+        ref_degs = self.view_instruments()["reference_designator"].values
         if self._data_type == 'netcdf':
             turls = self._perform_check()
             if len(turls) > 0:
                 self._logger.info('Acquiring data from opendap urls ...')
-                jobs = [gevent.spawn(fetch_xr, url, **kwargs) for url in turls]
+                jobs = [gevent.spawn(fetch_xr, (url, ref_degs), **kwargs) for url in turls]
                 gevent.joinall(jobs, timeout=300)
                 dataset_list = [job.value for job in jobs]
         else:

--- a/yodapy/datasources/ooi/__init__.py
+++ b/yodapy/datasources/ooi/__init__.py
@@ -381,7 +381,7 @@ class OOI(DataSource):
         # TODO: What to do when it's JSON request, calling on to_xarray.
         # TODO: Standardize the structure of the netCDF to ensure CF compliance.
         # TODO: Add way to specify instruments to convert to xarray
-        ref_degs = self._filtered_instruments()["reference_designator"].values
+        ref_degs = self._filtered_instruments["reference_designator"].values
         if self._data_type == 'netcdf':
             turls = self._perform_check()
             if len(turls) > 0:

--- a/yodapy/datasources/ooi/helpers.py
+++ b/yodapy/datasources/ooi/helpers.py
@@ -69,10 +69,13 @@ def download_all_nc(turl, folder):
     return ncfiles
 
 
-def fetch_xr(turl, **kwargs):
+def fetch_xr(params, **kwargs):
+    turl, ref_degs = params
     datasets = get_nc_urls(turl)
+    # only include instruments where ref_deg appears twice (i.e. was in original filter)
+    filt_ds = list(filter(lambda x: any(x.count(ref) > 1 for ref in ref_degs), datasets))
     return xr.open_mfdataset(
-        datasets,
+        filt_ds,
         preprocess=preprocess_ds,
         decode_times=False,
         **kwargs)


### PR DESCRIPTION
This PR prevents yodapy from downloading NC files for instruments not included in the original `search` call. Resolves #63. 

I.e., if the data request is only for nitrate, yodapy will ignore urls in the data indicating non-nitrate instruments.

Also adds extra items to gitignore.