### PR TITLE
Added dask and netCDF4 to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ lxml
 grequests
 gevent
 siphon
+dask
+netCDF4


### PR DESCRIPTION
## Overview

Dask and netCDF4 are required to run yodapy.

Related to https://github.com/oceanhackweek/ohw18_yoda_im/issues/27