### PR TITLE
Add close figure to save memory

### DIFF
--- a/yodapy/datasources/ooi/__init__.py
+++ b/yodapy/datasources/ooi/__init__.py
@@ -242,6 +242,7 @@ class OOI(DataSource):
                 ax.set_yticklabels(x)
                 ax.xaxis_date()
 
+                plt.close()
                 return instruments_avail
             else:
                 self._logger.warning('Dataframe is empty...')


### PR DESCRIPTION
## Overview

Calling `data_availibility` multiple times creates new figures everytime, and they don't auto close, which is a problem. This PR should address this, by closing figure after creation.
