### PR TITLE
Fix fillmismatch

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,9 +9,8 @@ gspread
 siphon
 dask
 seaborn
-# Hardcoded because the latest 1.4.2 giving OSError when reading opendap.
-# OSError: [Errno -45] NetCDF: Not a valid data type or _FillValue type mismatch
-netcdf4==1.4.1
+# Current fix to _fillmismatch problem described in https://github.com/cormorack/yodapy/issues/111
+netcdf4
 oauth2client
 progressbar2
 s3fs

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -73,7 +73,7 @@ def test_get_nc_urls():
         "-RS03AXPS-PC03A-4A-CTDPFA303-streamed-ctdpf_"
         "optode_sample/deployment0004_RS03AXPS-PC03A-4A"
         "-CTDPFA303-streamed-ctdpf_optode_sample_20180101T000000."
-        "596438-20180131T235959.815406.nc"
+        "596438-20180131T235959.815406.nc#fillmismatch"
     ]
 
     assert isinstance(dataset_urls, list)

--- a/yodapy/utils/parser.py
+++ b/yodapy/utils/parser.py
@@ -117,7 +117,7 @@ def get_nc_urls(thredds_url, download=False, cloud_source=False, **kwargs):
 
         # Note: `#fillmismatch` addition to dataset netcdf url is currently a workaround.
         # This needs to be fixed in the data provider end.
-        dataset_urls = [(d.access_urls[urltype] + '#fillmismatch') if urltype ==  # noqa
+        dataset_urls = [f'{d.access_urls[urltype]}#fillmismatch' if urltype ==  # noqa
                         'OPENDAP' else d.access_urls[urltype] for d in ncfiles]
 
     return dataset_urls

--- a/yodapy/utils/parser.py
+++ b/yodapy/utils/parser.py
@@ -112,15 +112,14 @@ def get_nc_urls(thredds_url, download=False, cloud_source=False, **kwargs):
                 f"Data not found for specified date range: {strbd} - {stred}"
             )
     else:
-        ncfiles = list(
-            filter(
-                lambda d: not any(
-                    w in d.name for w in ["json", "txt", "ncml"]
-                ),  # noqa
-                [cat.datasets[i] for i, d in enumerate(datasets)],
-            )
-        )  # noqa
-        dataset_urls = [d.access_urls[urltype] for d in ncfiles]
+        ncfiles = list(filter(lambda d: not any(w in d.name for w in ['json', 'txt', 'ncml']),  # noqa
+                        [cat.datasets[i] for i, d in enumerate(datasets)]))  # noqa
+
+        # Note: `#fillmismatch` addition to dataset netcdf url is currently a workaround.
+        # This needs to be fixed in the data provider end.
+        dataset_urls = [(d.access_urls[urltype] + '#fillmismatch') if urltype ==  # noqa
+                        'OPENDAP' else d.access_urls[urltype] for d in ncfiles]
+
     return dataset_urls
 
 


### PR DESCRIPTION
## Overview

This PR adds the workaround of `#fillmismatch` at the end of the netcdf URL. This closes #111. Now netcdf4 package is not pinned down.
